### PR TITLE
feat: dynamic db and schema names

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,10 +25,7 @@ clean-targets: # directories to be removed by `dbt clean`
 
 vars:
   truncate_timespan_to: "{{ current_timestamp() }}"
-  jaffle_db_name: "{{ env_var('JAFFLE_DB_NAME', 'jaffle_shop'}}) }}"
-  jaffle_db_path: "{{ env_var('JAFFLE_DB_PATH', './reports/jaffle_shop.duckdb') }}"
   jaffle_raw_schema: "{{ env_var('JAFFLE_RAW_SCHEMA', 'jaffle_raw'}}) }}"
-  jaffle_target_schema: "{{ env_var('JAFFLE_TARGET_SCHEMA', 'analytics'}}) }}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,6 +25,10 @@ clean-targets: # directories to be removed by `dbt clean`
 
 vars:
   truncate_timespan_to: "{{ current_timestamp() }}"
+  jaffle_db_name: "{{ env_var('JAFFLE_DB_NAME', 'jaffle_shop'}}) }}"
+  jaffle_db_path: "{{ env_var('JAFFLE_DB_PATH', './reports/jaffle_shop.duckdb') }}"
+  jaffle_raw_schema: "{{ env_var('JAFFLE_RAW_SCHEMA', 'jaffle_raw'}}) }}"
+  jaffle_target_schema: "{{ env_var('JAFFLE_TARGET_SCHEMA', 'analytics'}}) }}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,7 +25,6 @@ clean-targets: # directories to be removed by `dbt clean`
 
 vars:
   truncate_timespan_to: "{{ current_timestamp() }}"
-  jaffle_raw_schema: "{{ env_var('JAFFLE_RAW_SCHEMA', 'jaffle_raw'}}) }}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/models/staging/__sources.yml
+++ b/models/staging/__sources.yml
@@ -5,7 +5,9 @@ sources:
     schema: "{{ env_var('JAFFLE_RAW_SCHEMA', 'jaffle_raw') }}"
     description: E-commerce data
     meta:
-      external_location: "read_csv_auto('./jaffle-data/{name}.csv', header=1)"
+      # If `$JAFFLE_RAW_SCHEMA` is specified, use the provided raw data. Otherwise, use the csv seed data from the repo.
+      external_location: >-
+        {{ '' if env_var('JAFFLE_RAW_SCHEMA', '') else 'read_csv_auto("./jaffle-data/{name}.csv", header=1)' }}
 
     tables:
       - name: raw_customers

--- a/models/staging/__sources.yml
+++ b/models/staging/__sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: ecom
-    schema: "{{ var('jaffle_raw_schema') }}"
+    schema: "{{ env_var('JAFFLE_RAW_SCHEMA', 'jaffle_raw') }}"
     description: E-commerce data
     meta:
       external_location: "read_csv_auto('./jaffle-data/{name}.csv', header=1)"

--- a/models/staging/__sources.yml
+++ b/models/staging/__sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: ecom
-    schema: "{{target.schema}}_raw"
+    schema: "{{ var('jaffle_raw_schema') }}"
     description: E-commerce data
     meta:
       external_location: "read_csv_auto('./jaffle-data/{name}.csv', header=1)"

--- a/profiles.yml
+++ b/profiles.yml
@@ -2,8 +2,8 @@ duckdb:
   outputs:
     dev:
       type: duckdb
-      path: ./reports/jaffle_shop.duckdb
+      path: "{{ var('jaffle_db_path') }}"
+      database: "{{ var('jaffle_db_name') }}"
+      schema: "{{ var('jaffle_target_schema') }}"
       threads: 4
-      database: jaffle_shop
-      schema: analytics
   target: dev

--- a/profiles.yml
+++ b/profiles.yml
@@ -2,8 +2,8 @@ duckdb:
   outputs:
     dev:
       type: duckdb
-      path: "{{ var('jaffle_db_path') }}"
-      database: "{{ var('jaffle_db_name') }}"
-      schema: "{{ var('jaffle_target_schema') }}"
+      path: "{{ env_var('JAFFLE_DB_PATH', './reports/jaffle_shop.duckdb') }}"
+      database: "{{ env_var('JAFFLE_DB_NAME', 'jaffle_shop') }}"
+      schema: "{{ env_var('JAFFLE_TARGET_SCHEMA', 'analytics') }}"
       threads: 4
   target: dev


### PR DESCRIPTION
This PR introduces 4 environment variables which may be (optionally) used to control the mapping of inputs and outputs.

- `JAFFLE_DB_PATH` - defaults to `'./reports/jaffle_shop.duckdb'` (no change unless overridden)
- `JAFFLE_DB_NAME` - defaults to `'jaffle_shop'` (no change unless overridden)
- `JAFFLE_RAW_SCHEMA` - defaults to `'jaffle_raw'` (previously `'analytics_raw'`)
- `JAFFLE_TARGET_SCHEMA` - defaults to `'analytics'` (no change unless overridden)

The goal with this PR is to make core input and outputs configurable/swappable, while not breaking existing functionality.

## Related

- This mirrors a PR against my own fork here (CI tests passed): https://github.com/MeltanoLabs/jaffle-shop-template/pull/2
- This simplifies another WIP PR currently targeting my own fork: https://github.com/MeltanoLabs/jaffle-shop-template/pull/1