### PR TITLE
Add install and db env vars to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,12 @@
     "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:0": {}
   },
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "python -m pip install --user -r requirements.txt && dbt deps",
+  "postCreateCommand": "python -m pip install --user -r requirements.txt && dbt deps && npm --prefix ./reports install",
+  // Set environment variables for evidence database connection
+  "remoteEnv": {
+    "DATABASE": "duckdb",
+    "FILENAME": "jaffle_shop.duckdb"
+  },
   // Configure tool-specific properties
   "customizations": {
     "vscode": {


### PR DESCRIPTION
This template is fantastic!

We've been thinking of ways to make it easier to get started with the `reports` directory and came up with these ideas:
1. Add `npm install` to the `postCreateCommand` in `.devcontainer/devcontainer.json` so it doesn't need to be run the first time you go into the `reports` directory
2. Add environment variables for the duckdb connection so you don't need to enter them in the settings menu in Evidence 

Before these changes, the steps to get started would be:
1. `cd reports`
2. `npm install`
3. `npm run dev`
4. Settings > enter db info

Afterwards, the steps would be:
1. `cd reports`
2. `npm run dev`

### Database Environment Variables
In this PR, I've set the following environment variables so Evidence can automatically pick up the db connection:
- `DATABASE` - "duckdb"
- `FILENAME` - "jaffle_shop.duckdb"

I noticed that @aaronsteers recently added a way to dynamically set db and schema names, so this may conflict with that approach. If this conflicts with those variables, I can remove these from the PR!
