### PR TITLE
Add .venv and npm to container build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:0": {}
   },
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "python -m pip install --user -r requirements.txt && dbt deps",
+  "postCreateCommand": "python -m venv .venv && . .venv/bin/activate && python -m pip install -r requirements.txt && dbt deps && npm --prefix ./reports install",
   // Configure tool-specific properties
   "customizations": {
     "vscode": {
@@ -15,26 +15,24 @@
         "terminal.integrated.defaultProfile.linux": "zsh"
       },
       "extensions": [
-		"GitHub.codespaces",
-		"GitHub.vscode-pull-request-github",
-		"esbenp.prettier-vscode",
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"ms-python.black-formatter",
-		"ms-python.isort",
-		"charliermarsh.ruff",
-		"redhat.vscode-yaml",
-		"samuelcolvin.jinjahtml",
-		"bungcip.better-toml",
-		"tamasfe.even-better-toml",
-		"dorzey.vscode-sqlfluff",
-		"mechatroner.rainbow-csv",
-		"evidence.evidence-vscode",
-		"svelte.svelte-vscode",
-		"bastienboutonnet.vscode-dbt",
-		"innoverio.vscode-dbt-power-user",
-		"cschleiden.vscode-github-actions"
-	]
+        "GitHub.codespaces",
+        "GitHub.vscode-pull-request-github",
+        "esbenp.prettier-vscode",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "charliermarsh.ruff",
+        "redhat.vscode-yaml",
+        "samuelcolvin.jinjahtml",
+        "bungcip.better-toml",
+        "tamasfe.even-better-toml",
+        "dorzey.vscode-sqlfluff",
+        "mechatroner.rainbow-csv",
+        "evidence.evidence-vscode",
+        "svelte.svelte-vscode",
+        "bastienboutonnet.vscode-dbt"
+      ]
     }
   }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "innoverio.vscode-dbt-power-user",
+    "cschleiden.vscode-github-actions"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,17 +6,9 @@
   "sqlfluff.executablePath": ".venv/bin/sqlfluff",
   "python.defaultInterpreterPath": ".venv/bin/python",
   "sqlfluff.experimental.format.executeInTerminal": true,
+
   "[jinja-sql]": {
     "editor.defaultFormatter": "dorzey.vscode-sqlfluff",
     "editor.formatOnSave": false
-  },
-  "sqltools.useNodeRuntime": true,
-  "sqltools.connections": [
-    {
-      "previewLimit": 50,
-      "driver": "DuckDB",
-      "name": "jaffle_shop",
-      "database": "${workspaceFolder:jaffle-shop-template}/reports/jaffle_shop.duckdb"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Per idea from Evidence this PR add npm install to the container build, it also, although unnecessary in a container, adds a virtual environment so that settings are correct and consistent between local and dev container development. Closes #10 #11 

It also move dbt Power User to a recommended rather than automatically installed extension, since it seems to have issues with order of operations and throws error about dbt not being installed, the python extension not being installed, etc. We can troubleshoot those at some point but for now I'd rather not have known errors on build for this. Closes #12 