### PR TITLE
Remove dbt power user from extension recs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
         "GitHub.vscode-pull-request-github",
         "cschleiden.vscode-github-actions",
         "esbenp.prettier-vscode",
+        "ms-python.python",
         "ms-python.vscode-pylance",
         "ms-python.black-formatter",
         "ms-python.isort",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["ms-python.python", "innoverio.vscode-dbt-power-user"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-  "dbt.queryLimit": 100,
-  "dbt.profilesDirOverride": ".",
   "python.analysis.typeCheckingMode": "basic",
   "sqlfluff.dialect": "duckdb",
   "sqlfluff.experimental.format.executeInTerminal": true,


### PR DESCRIPTION
It consistently throws a (meaningless) error on install and requires a little bit of coaching to find dbt and work properly. The functionality would be welcome so we should sort this out at some point, but for now I want the startup to be as clean as possible.